### PR TITLE
Initialize Gatsby Netlify project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # kris-gatsby-codex
-Repository used to test AI codex and Gatsby React
+
+This repository contains a simple Gatsby site configured for deployment on Netlify. It includes a basic portfolio starter library in `src/components/Portfolio.js`.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+3. Create a production build:
+   ```bash
+   npm run build
+   ```
+
+## Deploying to Netlify
+
+Connect this repository to Netlify and set the build command to `npm run build` and the publish directory to `public`.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  siteMetadata: {
+    title: 'Kris Gatsby Codex',
+    description: 'Sample Gatsby portfolio deployed on Netlify',
+    author: 'Kris'
+  },
+  plugins: ['gatsby-plugin-netlify']
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "kris-gatsby-codex",
+  "version": "1.0.0",
+  "description": "Repository used to test AI codex and Gatsby React",
+  "main": "index.js",
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "start": "gatsby develop"
+  },
+  "keywords": ["gatsby", "portfolio"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "gatsby": "^5.12.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "gatsby-plugin-netlify": "^5.12.0"
+  }
+}

--- a/src/components/Portfolio.js
+++ b/src/components/Portfolio.js
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+const projects = [
+  { title: 'First Project', description: 'A wonderful project' },
+  { title: 'Second Project', description: 'Another great project' }
+];
+
+export default function Portfolio() {
+  return (
+    <section>
+      <h2>Portfolio Starter Library</h2>
+      <ul>
+        {projects.map(project => (
+          <li key={project.title}>
+            <strong>{project.title}</strong> - {project.description}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export default function NotFoundPage() {
+  return (
+    <main>
+      <h1>Page Not Found</h1>
+    </main>
+  );
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import Portfolio from '../components/Portfolio';
+
+const IndexPage = () => (
+  <main>
+    <h1>Welcome to Kris Gatsby Codex</h1>
+    <Portfolio />
+  </main>
+);
+
+export default IndexPage;


### PR DESCRIPTION
## Summary
- set up a minimal Gatsby site with a portfolio component
- add Netlify plugin configuration
- document setup and deployment instructions

## Testing
- `npm run build` *(fails: gatsby not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5922af6883268a178a6473451dc0